### PR TITLE
Add weighted averages + bootstrapped errors

### DIFF
--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 
-def coadd_flux(wave, flux, ivar, mask=None, method="mean", n_workers=1):
+def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_workers=1):
     """ Coadd spectra using S/N weighted mean. """
-    methods = ["mean", "median", "ivar-weighted-mean"]
+    methods = ["mean", "median", "ivar-weighted-mean", "spec-weighted-mean"]
     if method not in methods:
         raise ValueError(f"Coadd type must be one of {methods}")
     if method == "mean":
@@ -11,4 +11,14 @@ def coadd_flux(wave, flux, ivar, mask=None, method="mean", n_workers=1):
     elif method == "median":
         return np.nanmedian(flux, axis=0)
     elif method == "ivar-weighted-mean":
-        raise NotImplementedError
+        weight = ivar
+        nan_mask = (np.isnan(flux)) | (np.isnan(weight))
+        flux[nan_mask] = 0.0
+        weight[nan_mask] = 0.0
+        return np.average(flux, weights=weight, axis=0)
+    elif method == "spec-weighted-mean":
+        if np.any(weight==None):
+            raise ValueError(f"Weight must be specified when performing a weighted average.")
+        nan_mask = (np.isnan(flux))
+        #flux[nan_mask] = 0.0
+        return np.average(flux, weights=weight, axis=0)

--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -1,20 +1,21 @@
+import multiprocessing
+from joblib import Parallel, delayed
 import numpy as np
+import matplotlib.pyplot as plt
 
 
-def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_workers=1):
+def _coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None):
     """ Coadd spectra using S/N weighted mean. """
     methods = ["mean", "median", "ivar-weighted-mean", "irms-weighted-mean"]
-    if np.all(weight==None):
-        weight = np.ones(len(flux))
     if method not in methods:
         raise ValueError(f"Coadd type must be one of {methods}")
     if method == "mean":
         wl_weight = np.ones_like(flux) * np.expand_dims(weight, axis=-1)
         nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
         flux[nan_mask] = 0.0
-        wl_weight[nan_mask] = 0.0
+        wl_weight[nan_mask] = 1e-10 # hack
         stacked_flux = np.average(flux, weights=wl_weight, axis=0)
-        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        stacked_flux[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
         return stacked_flux
     elif method == "median":
         return np.nanmedian(flux, axis=0)
@@ -22,18 +23,66 @@ def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_worker
         wl_weight = ivar * np.expand_dims(weight, axis=-1)
         nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
         flux[nan_mask] = 0.0
-        wl_weight[nan_mask] = 0.0
+        wl_weight[nan_mask] = 1e-10 # hack
         stacked_flux = np.average(flux, weights=wl_weight, axis=0)
-        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        stacked_flux[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
         return stacked_flux
     elif method == "irms-weighted-mean":
         wl_weight = ivar**0.5 * np.expand_dims(weight, axis=-1)
         nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
         flux[nan_mask] = 0.0
-        wl_weight[nan_mask] = 0.0
+        wl_weight[nan_mask] = 1e-10 # hack
         stacked_flux = np.average(flux, weights=wl_weight, axis=0)
-        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        stacked_flux[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
         return stacked_flux
-    
+
+def bootstrap_coadd(wave, flux, ivar, mask=None, method="mean", weight=None):
+    boot_idx = np.random.choice(
+        np.arange(len(flux)), replace=True, size=np.max([10,int(len(flux)/10)])
+    )  # take a random sample each iteration
+    boot_coadd = _coadd_flux(
+        wave, flux[boot_idx], ivar[boot_idx], mask=mask, method=method, weight=weight[boot_idx]
+    )  # calculate the mean for each iteration
+    #plt.plot(wave, boot_coadd)
+    #plt.show()
+    return boot_coadd
 
 
+def coadd_flux(
+    wave,
+    flux,
+    ivar,
+    mask=None,
+    method="mean",
+    weight=None,
+    stack_error="bootstrap",
+    n_workers=1,
+):
+    if np.all(weight==None):
+        weight = np.ones(len(flux))
+    stack_errors = ["no-errors", "bootstrap"]
+    if stack_error not in stack_errors:
+        raise ValueError(f"Coadd type must be one of {stack_errors}")
+    if stack_error == "no-errors":
+        return _coadd_flux(wave, flux, ivar, mask=mask, method=method, weight=weight)
+    if stack_error == "bootstrap":
+        if n_workers == 1:
+            boot_averages = np.array(
+                [
+                    bootstrap_coadd(
+                        wave, flux, ivar, mask=mask, method=method, weight=weight
+                    )
+                    for _ in range(100)
+                ]
+            )
+            return np.nanmean(boot_averages, axis=0), np.nanstd(boot_averages, axis=0)
+        else:
+            boot_averages = np.array(
+                Parallel(n_jobs=n_workers)(
+                    delayed(bootstrap_coadd)(
+                        wave, flux, ivar, mask=mask, method=method, weight=weight
+                    )
+                    for _ in range(100)
+                )
+            )
+            return np.nanmean(boot_averages, axis=0), np.nanstd(boot_averages, axis=0)

--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -3,22 +3,37 @@ import numpy as np
 
 def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_workers=1):
     """ Coadd spectra using S/N weighted mean. """
-    methods = ["mean", "median", "ivar-weighted-mean", "spec-weighted-mean"]
+    methods = ["mean", "median", "ivar-weighted-mean", "istd-weighted-mean"]
+    if np.all(weight==None):
+        weight = np.ones(len(flux))
     if method not in methods:
         raise ValueError(f"Coadd type must be one of {methods}")
     if method == "mean":
-        return np.nanmean(flux, axis=0)
+        wl_weight = np.ones_like(flux) * np.expand_dims(weight, axis=-1)
+        nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
+        flux[nan_mask] = 0.0
+        wl_weight[nan_mask] = 0.0
+        stacked_flux = np.average(flux, weights=wl_weight, axis=0)
+        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        return stacked_flux
     elif method == "median":
         return np.nanmedian(flux, axis=0)
     elif method == "ivar-weighted-mean":
-        weight = ivar
-        nan_mask = (np.isnan(flux)) | (np.isnan(weight))
+        wl_weight = ivar * np.expand_dims(weight, axis=-1)
+        nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
         flux[nan_mask] = 0.0
-        weight[nan_mask] = 0.0
-        return np.average(flux, weights=weight, axis=0)
-    elif method == "spec-weighted-mean":
-        if np.any(weight==None):
-            raise ValueError(f"Weight must be specified when performing a weighted average.")
-        nan_mask = (np.isnan(flux))
-        #flux[nan_mask] = 0.0
-        return np.average(flux, weights=weight, axis=0)
+        wl_weight[nan_mask] = 0.0
+        stacked_flux = np.average(flux, weights=wl_weight, axis=0)
+        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        return stacked_flux
+    elif method == "istd-weighted-mean":
+        wl_weight = ivar**0.5 * np.expand_dims(weight, axis=-1)
+        nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
+        flux[nan_mask] = 0.0
+        wl_weight[nan_mask] = 0.0
+        stacked_flux = np.average(flux, weights=wl_weight, axis=0)
+        #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
+        return stacked_flux
+    
+
+

--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -38,7 +38,7 @@ def _coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None):
 
 def bootstrap_coadd(wave, flux, ivar, mask=None, method="mean", weight=None):
     boot_idx = np.random.choice(
-        np.arange(len(flux)), replace=True, size=np.max([10,int(len(flux)/10)])
+        np.arange(len(flux)), replace=True, size=len(flux)
     )  # take a random sample each iteration
     boot_coadd = _coadd_flux(
         wave, flux[boot_idx], ivar[boot_idx], mask=mask, method=method, weight=weight[boot_idx]
@@ -57,6 +57,7 @@ def coadd_flux(
     weight=None,
     stack_error="bootstrap",
     n_workers=1,
+    bootstrap_samples=1000,
 ):
     if np.all(weight==None):
         weight = np.ones(len(flux))
@@ -72,7 +73,7 @@ def coadd_flux(
                     bootstrap_coadd(
                         wave, flux, ivar, mask=mask, method=method, weight=weight
                     )
-                    for _ in range(100)
+                    for _ in range(bootstrap_samples)
                 ]
             )
             return np.nanmean(boot_averages, axis=0), np.nanstd(boot_averages, axis=0)
@@ -82,7 +83,7 @@ def coadd_flux(
                     delayed(bootstrap_coadd)(
                         wave, flux, ivar, mask=mask, method=method, weight=weight
                     )
-                    for _ in range(100)
+                    for _ in range(bootstrap_samples)
                 )
             )
             return np.nanmean(boot_averages, axis=0), np.nanstd(boot_averages, axis=0)

--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_workers=1):
     """ Coadd spectra using S/N weighted mean. """
-    methods = ["mean", "median", "ivar-weighted-mean", "istd-weighted-mean"]
+    methods = ["mean", "median", "ivar-weighted-mean", "irms-weighted-mean"]
     if np.all(weight==None):
         weight = np.ones(len(flux))
     if method not in methods:
@@ -26,7 +26,7 @@ def coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None, n_worker
         stacked_flux = np.average(flux, weights=wl_weight, axis=0)
         #stacked_flux[np.sum(nan_mask, axis=0)!=0] = np.nan # only allow wl which is covered by all spectra
         return stacked_flux
-    elif method == "istd-weighted-mean":
+    elif method == "irms-weighted-mean":
         wl_weight = ivar**0.5 * np.expand_dims(weight, axis=-1)
         nan_mask = (np.isnan(flux)) | (np.isnan(wl_weight))
         flux[nan_mask] = 0.0

--- a/py/desigal/specutils/stack.py
+++ b/py/desigal/specutils/stack.py
@@ -54,10 +54,15 @@ def stack_spectra(
     # Coadd cameras if needed
     if isinstance(flux, dict):
         flux, wave, ivar, mask = coadd_cameras(flux, wave, ivar, mask)
+    
+    # MW dust correct
+    flux_mwcorr = mw_dust_correct(flux, wave, fibermap["TARGET_RA"], fibermap["TARGET_DEC"], "flux")
+    ivar_mwcorr = mw_dust_correct(ivar, wave, fibermap["TARGET_RA"], fibermap["TARGET_DEC"], "ivar")
+
     # de-redshfit the spectra
-    flux_dered = deredshift(flux, redshift, stack_redshfit, "flux")
+    flux_dered = deredshift(flux_mwcorr, redshift, stack_redshfit, "flux")
     wave_dered = deredshift(wave, redshift, stack_redshfit, "wave")
-    ivar_dered = deredshift(ivar, redshift, stack_redshfit, "ivar")
+    ivar_dered = deredshift(ivar_mwcorr, redshift, stack_redshfit, "ivar")
 
     # resample the spectra to a common grid
     if output_wave_grid is None:
@@ -91,6 +96,7 @@ def stack_spectra(
         ivar_normed,
         method=stack_method,
         n_workers=n_workers,
+        weight=weight
     )
 
     return stacked_spectra, output_wave_grid

--- a/py/desigal/specutils/stack.py
+++ b/py/desigal/specutils/stack.py
@@ -26,6 +26,7 @@ def stack_spectra(
     weight=None,
     stack_method="mean",
     stack_error="bootstrap",
+    bootstrap_samples=1000,
     n_workers=-1,
 ):
     if spectra is None:


### PR DESCRIPTION
Hi,

This pull request includes a few different additions to the stacking code. I think it should take care of issues #10 and #11 .

**Weighted averages:**
I have included ivar and irms weighted averages per wavelength bin. On top of that it is also possible to up of down weight specific (as in one weight per spectrum) spectra using the `weight` argument in the main stacking function. These two weights can be used in conjunction where `total_weight = wl_weight * spec_weight`.

**Bootstrap errors:**
Errors using bootstrap sampling. The default setting is `bootstrap_samples=1000`. For each bootstrap we are sampling with replacement a bootstrap sample of equal length as the original sample. The bootstrap sampling can be run in parallel using the `n_workers` argument.

_Currently the stacking code will return a stacked spectrum when for the wl range covered by at least 1 spectrum but we might want to change this to a slightly more sane criterium at some point._

Stacking example with bootstrapped errors:
![image](https://user-images.githubusercontent.com/35468336/205888888-42750db8-6ff6-4b11-8f69-0e7c901199f6.png)

**Add MW foreground correction to the main stacking function:**
I have now added the MW foreground correction to the main stacking function. 

Let me know if you think there are any changes that should be made before we integrate this into the main branch! 🙂 