### PR TITLE
updates to add luminosity normalization and other changes

### DIFF
--- a/py/desigal/specutils/coaddition.py
+++ b/py/desigal/specutils/coaddition.py
@@ -20,8 +20,22 @@ def _coadd_flux(wave, flux, ivar, mask=None, method="mean", weight=None):
         stacked_ivar = (np.sum(wl_weight**2 * ivar**-1, axis=0)/(np.sum(wl_weight, axis=0)**2))**-1
         stacked_ivar[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
         return np.stack([stacked_flux, stacked_ivar], axis=-1)
-    elif method == "median":
-        return np.nanmedian(flux, axis=0)
+    if method == "median":
+        wl_weight = np.ones_like(flux) * np.expand_dims(weight, axis=-1)
+        nan_mask = (np.isnan(flux)) | (np.isnan(ivar)) | (ivar==0.) | (np.isnan(wl_weight))
+        flux[nan_mask] = 0.0
+        ivar[nan_mask] = 1e-10 # hack
+        wl_weight[nan_mask] = 1e-10 # hack
+        stacked_flux = np.zeros((flux.shape[1]))
+        for i in range(len(stacked_flux)):
+            stacked_flux[i] = weighted_quantiles(flux[:,i], weights=wl_weight[:,i], quantiles=0.5)
+        stacked_flux[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
+        stacked_ivar = (np.sum(wl_weight**2 * ivar**-1, axis=0)/(np.sum(wl_weight, axis=0)**2))**-1
+        stacked_ivar[np.sum(~nan_mask, axis=0)==0] = np.nan # only allow wl which is covered by at least 1 spectrum
+        print(np.nansum(stacked_flux))
+        return np.stack([stacked_flux, stacked_ivar], axis=-1)
+    #elif method == "median":
+    #    return np.nanmedian(flux, axis=0)
     elif method == "ivar-weighted-mean":
         wl_weight = ivar * np.expand_dims(weight, axis=-1)
         nan_mask = (np.isnan(flux)) | (np.isnan(ivar)) | (ivar==0.) | (np.isnan(wl_weight))
@@ -99,3 +113,8 @@ def coadd_flux(
                 )
             )
             return np.nanmean(boot_averages[:,:,0], axis=0), np.nanmean(boot_averages[:,:,1], axis=0)
+
+def weighted_quantiles(values, weights, quantiles=0.5, axis=0):
+    i = np.argsort(values, axis=axis)
+    c = np.cumsum(weights[i], axis=axis)
+    return values[i[np.searchsorted(c, np.array(quantiles) * c[-1])]]


### PR DESCRIPTION
Several changes to the code (some a little ugly...)

**Update "median" option in coaddition of spectra:**
I have updated this option to be able to take in specified weights now to calculate the weighted median. When using no weights (i.e. just using the mean as the stack method) the plain median is still returned.

**Hack to fix a very rare error in the flux-window stack method:**
Fixes this issue https://github.com/desihub/desigal/issues/18

A more elegant solution would be nice!

**Add luminosity normalization option:**
This converts the spectral flux to luminosities (output units 10^39 erg AA^-1 s^-1).
Keep in mind that this is the conversion of the in-fiber flux, some aperture correction using the multiplication_factor input in the stack optional arguments is needed at lower redshifts.

