### PR TITLE
put SN conserving code

### DIFF
--- a/py/desigal/specutils/resample.py
+++ b/py/desigal/specutils/resample.py
@@ -12,7 +12,6 @@ import multiprocessing
 from joblib import Parallel, delayed
 import numpy as np
 import desispec
-from desispec.quicklook.palib import resample_spec
 from desispec.interpolation import resample_flux
 
 


### PR DESCRIPTION
This PR resolves fixes #30. It seems that the flux conserving resampler was removed from desispec as part of code clean up. I have copied that code here so that the functionality is preserved.